### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -5,6 +5,8 @@
 ###########################
 ###########################
 name: Lint Code Base
+permissions:
+  contents: read
 
 #
 # Documentation:


### PR DESCRIPTION
Potential fix for [https://github.com/Zen-CODE/zenplayer/security/code-scanning/1](https://github.com/Zen-CODE/zenplayer/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to limit the GITHUB_TOKEN to the minimum required set. In this workflow, the only necessary permission is to read repository contents, so at either the workflow or job level, add `permissions: contents: read`. Since there's only one job, it's preferable to set it at the workflow (top) level to apply globally. This change should be inserted after the `name: Lint Code Base` declaration on line 7.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
